### PR TITLE
Preserve intended logic

### DIFF
--- a/atomics/race-fixed/main.go
+++ b/atomics/race-fixed/main.go
@@ -12,15 +12,15 @@ func main() {
 	wg.Add(5)
 	go func() {
 		defer wg.Done()
-		atomic.StoreInt32(&count, 10)
+		atomic.AddInt32(&count, 10)
 	}()
 	go func() {
 		defer wg.Done()
-		atomic.StoreInt32(&count, -15)
+		atomic.AddInt32(&count, -15)
 	}()
 	go func() {
 		defer wg.Done()
-		atomic.StoreInt32(&count, 1)
+		atomic.AddInt32(&count, 1)
 	}()
 	go func() {
 		defer wg.Done()


### PR DESCRIPTION
in `atomics/rage/main.go` the first 3 routines perform addition or subtraction, not an update 

would be useful for learning fellows to have the video updated, too (overlay comment)